### PR TITLE
Removed descriptorCache reassignment error.

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -4,9 +4,6 @@ import hash from 'hash-sum'
 const descriptorCache: Record<string, SFCDescriptor> = {}
 
 export function setDesCache(filename: string, descriptor: SFCDescriptor) {
-    if (descriptorCache[filename]) {
-        throw new Error('descriptor cache has already been set')
-    }
     descriptorCache[filename] = descriptor
 }
 


### PR DESCRIPTION
This error is hit when ESBuild runs in watch mode. After a change is made in the source code, the plugin re-runs and then fails because the files are already in the descriptorCache. This change removes that reassignment error and allows the descriptor to be updated based on the most recent changes in the source code.